### PR TITLE
Fix casting warnings in ContactSaveService

### DIFF
--- a/src/com/android/contacts/ContactSaveService.java
+++ b/src/com/android/contacts/ContactSaveService.java
@@ -1218,13 +1218,13 @@ public class ContactSaveService extends IntentService {
                     R.plurals.contacts_deleted_toast, contactIds.length);
         } else if (names.length == 1) {
             deleteToastMessage = getResources().getString(
-                    R.string.contacts_deleted_one_named_toast, names);
+                    R.string.contacts_deleted_one_named_toast, (Object[]) names);
         } else if (names.length == 2) {
             deleteToastMessage = getResources().getString(
-                    R.string.contacts_deleted_two_named_toast, names);
+                    R.string.contacts_deleted_two_named_toast, (Object[]) names);
         } else {
             deleteToastMessage = getResources().getString(
-                    R.string.contacts_deleted_many_named_toast, names);
+                    R.string.contacts_deleted_many_named_toast, (Object[]) names);
         }
 
         mMainHandler.post(new Runnable() {


### PR DESCRIPTION
packages/apps/Contacts/src/com/android/contacts/ContactSaveService.java:1227: warning: non-varargs call of varargs method with inexact argument type for last parameter;
                    R.string.contacts_deleted_many_named_toast, names);
                                                                ^
  cast to Object for a varargs call
  cast to Object[] for a non-varargs call and to suppress this warning
1 warning

Test: make -j Contacts (no more warnings)
Change-Id: I244f376b2a8728598e66757742234fbf1a3557df